### PR TITLE
Update to v6.9.2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,8 +2,8 @@
 c_stdlib_version:  # [not linux]
   - 12.0           # [osx]
   - 2022.12        # [win]
-OSX_SDK_VER:
-  - 13.3
+OSX_SDK_VER:       # [osx]
+  - 13.3           # [osx]
 
 # https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
@@ -18,11 +18,7 @@ c_compiler_version:    # [osx]
 cxx_compiler_version:  # [osx]
   - 17                 # [osx]
 
-# Need at least a 12.0 host or else tests will fail.
-extra_labels_for_os:
-  osx-arm64: [ventura]
-
 # Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
-# 11.1 sysroot.
+# 12.1 sysroot.
 CONDA_BUILD_SYSROOT:
   - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qt5compat" %}
-{% set version = "6.9.1" %}
+{% set version = "6.9.2" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,11 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 96c726ac3f0d5c40570e75196e4ab5c95d3de7c85d15604fe97ac2a6573d917a
+    sha256: cb289905c689fc271ce783f8b67844040aa73d78f4f0cf8421fa713390a75b60
     folder: {{ name }}
 
 build:
   number: 0
-  skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 
@@ -35,6 +34,7 @@ requirements:
   host:
     - qtbase-devel {{ version }}
     - qtdeclarative {{ version }}
+    # https://github.com/qt/qt5compat/blob/v6.9.2/CMakeLists.txt#L24
     - qtshadertools {{ version }}
     - icu {{ icu }}
   run_constrained:
@@ -43,6 +43,7 @@ requirements:
 
 test:
   requires:
+    - {{ stdlib('c') }}  # [linux]
     - {{ compiler('cxx') }}
     - cmake
     - ninja

--- a/recipe/test/CMakeLists.txt
+++ b/recipe/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.16)
 
 set (CMAKE_BUILD_TYPE "Release" CACHE STRING "build type")
 


### PR DESCRIPTION
qt5compat 6.9.2

**Destination channel:** defaults

### Links

- [PKG-9669](https://anaconda.atlassian.net/browse/PKG-9669)
- [Upstream repository](https://github.com/qt/qt5compat/tree/v6.9.2)
- [Upstream changelog/diff](https://github.com/qt/qt5compat/compare/v6.9.1...v6.9.2)

[PKG-9669]: https://anaconda.atlassian.net/browse/PKG-9669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ