### PR TITLE
qt5compat 6.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216
-  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr9/e64e5f3
-  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr9/fb94a22
-  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/6d0b18c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr22/f9b7216
+  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr9/e64e5f3
+  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr9/fb94a22
+  - https://staging.continuum.io/pbp/fs/qtdeclarative-feedstock/pr9/6d0b18c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qt5compat" %}
-{% set version = "6.10.2" %}
+{% set version = "6.11.0" %}
 
 package:
   name: {{ name }}
@@ -35,7 +35,7 @@ requirements:
   host:
     - qtbase-devel {{ version }}
     - qtdeclarative {{ version }}
-    # https://github.com/qt/qt5compat/blob/v6.9.2/CMakeLists.txt#L24
+    # https://github.com/qt/qt5compat/blob/v6.11.0/CMakeLists.txt#L28
     - qtshadertools {{ version }}
     - icu {{ icu }}
 
@@ -63,7 +63,7 @@ test:
     {% endfor %}
 
 about:
-  home: https://www.qt.io/
+  home: https://www.qt.io
   license: LGPL-3.0-only
   license_file: {{ name }}/LICENSES/LGPL-3.0-only.txt
   license_family: LGPL
@@ -71,5 +71,5 @@ about:
   description: |
     Qt helps you create connected devices, UIs & applications that run
     anywhere on any device, on any operating system at any time ({{ name[2:] }} libraries).
-  doc_url: https://doc.qt.io/
+  doc_url: https://doc.qt.io
   dev_url: https://github.com/qt/{{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 3fa418f0fac02eb9efc5f762fbe25f20647b0ebb7fa92faf07e6de85044161c2
+    sha256: e62954646b2749723aa5c7db32faab407358734075590058a01e793382d4c63e
     folder: {{ name }}
 
 build:


### PR DESCRIPTION
qt5compat 6.11

**Destination channel:** defaults

### Links

- [PKG-11825](https://anaconda.atlassian.net/browse/PKG-11825) 
- [Upstream repository](https://github.com/qt/qt5compat/tree/v6.11.0)

### Explanation of changes:

- version update


[PKG-11825]: https://anaconda.atlassian.net/browse/PKG-11825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ