### PR TITLE
Rebuild against qtbase with libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     folder: {{ name }}
 
 build:
-  number: 1
+  number: 2
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
qt5compat 6.11.0

**Destination channel:**  defaults

### Links

- [PKG-15512](https://anaconda.atlassian.net/browse/PKG-15512) 
- [Upstream repository](https://github.com/qt/qt5compat/tree/v6.11.0)

### Explanation of changes:
- rebuild against qtbase with libjpeg-turbo


[PKG-15512]: https://anaconda.atlassian.net/browse/PKG-15512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ